### PR TITLE
feat(frontend): Pre-populate user profile form with current data

### DIFF
--- a/frontend/src/api/MyUserApi.tsx
+++ b/frontend/src/api/MyUserApi.tsx
@@ -1,5 +1,6 @@
+import { User } from '@/types';
 import { useAuth0 } from '@auth0/auth0-react';
-import { useMutation } from 'react-query';
+import { useMutation, useQuery } from 'react-query';
 import { toast } from 'sonner';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
@@ -114,4 +115,38 @@ export const useUpdateMyUser = () => {
     updateMyUser,
     isLoading,
   };
+};
+
+export const useGetMyUser = () => {
+  const { getAccessTokenSilently } = useAuth0();
+
+  const getMyUserRequest = async (): Promise<User> => {
+    const accessToken = await getAccessTokenSilently();
+    const response = await fetch(`${API_BASE_URL}/api/my/user`, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      throw new Error(errorData.message || 'Failed to fetch user');
+    }
+
+    return response.json();
+  };
+
+  const {
+    data: currentUser,
+    isLoading,
+    error,
+  } = useQuery('getMyUserRequest', getMyUserRequest);
+
+  if (error) {
+    toast.error(error.toString());
+  }
+
+  return { currentUser, isLoading };
 };

--- a/frontend/src/forms/user-profile-form/UserProfileForm.tsx
+++ b/frontend/src/forms/user-profile-form/UserProfileForm.tsx
@@ -9,7 +9,9 @@ import {
   FormLabel,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
+import { User } from '@/types';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
@@ -24,14 +26,20 @@ const formSchema = z.object({
 type UserFormData = z.infer<typeof formSchema>;
 
 type Props = {
+  currentUser: User;
   onSave: (userProfileData: UserFormData) => void;
   isLoading: boolean;
 };
 
-const UserProfileForm = ({ onSave, isLoading }: Props) => {
+const UserProfileForm = ({ currentUser, onSave, isLoading }: Props) => {
   const form = useForm<UserFormData>({
     resolver: zodResolver(formSchema),
+    defaultValues: currentUser,
   });
+
+  useEffect(() => {
+    form.reset(currentUser);
+  }, [currentUser, form]);
 
   return (
     <Form {...form}>

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -1,10 +1,25 @@
-import { useUpdateMyUser } from '@/api/MyUserApi';
+import { useGetMyUser, useUpdateMyUser } from '@/api/MyUserApi';
 import UserProfileForm from '@/forms/user-profile-form/UserProfileForm';
 
 const UserProfilePage = () => {
-  const { updateMyUser, isLoading } = useUpdateMyUser();
+  const { updateMyUser, isLoading: isUpdateLoading } = useUpdateMyUser();
+  const { currentUser, isLoading: isGetLoading } = useGetMyUser();
 
-  return <UserProfileForm isLoading={isLoading} onSave={updateMyUser} />;
+  if (isGetLoading) {
+    return <span>Loading...</span>;
+  }
+
+  if (!currentUser) {
+    return <span>Unable to load user profile</span>;
+  }
+
+  return (
+    <UserProfileForm
+      isLoading={isUpdateLoading}
+      onSave={updateMyUser}
+      currentUser={currentUser}
+    />
+  );
 };
 
 export default UserProfilePage;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,8 @@
+export type User = {
+  _id: string;
+  name: string;
+  email: string;
+  addressLine1: string;
+  city: string;
+  country: string;
+};


### PR DESCRIPTION
- Implement useGetMyUser hook for fetching current user data
- Update UserProfileForm to accept and display current user data
- Modify UserProfilePage to fetch and pass current user data
- Add User type definition for improved type safety`:wq 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR implements pre-population of the user profile form with current user data. It introduces a useGetMyUser hook, updates UserProfileForm to display fetched data, modifies UserProfilePage to fetch and pass user information, and adds a User type definition for improved type safety.
<br>
<br>
<b>Code change type</b>: Feature Addition, Refactoring
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>