### PR TITLE
feat(frontend): Protect route for the user profile page

### DIFF
--- a/frontend/src/AppRoutes.tsx
+++ b/frontend/src/AppRoutes.tsx
@@ -3,6 +3,7 @@ import Layout from './layouts/layout';
 import HomePage from './pages/HomePage';
 import AuthCallbackPage from './pages/AuthCallbackPage';
 import UserProfilePage from './pages/UserProfilePage';
+import ProtectedRoute from './auth/ProtectedRoute';
 
 const AppRoutes = () => {
   return (
@@ -16,14 +17,18 @@ const AppRoutes = () => {
         }
       />
       <Route path="/auth-callback" element={<AuthCallbackPage />} />
-      <Route
-        path="/user-profile"
-        element={
-          <Layout>
-            <UserProfilePage />
-          </Layout>
-        }
-      />
+
+      <Route element={<ProtectedRoute />}>
+        <Route
+          path="/user-profile"
+          element={
+            <Layout>
+              <UserProfilePage />
+            </Layout>
+          }
+        />
+      </Route>
+
       <Route path="*" element={<Navigate to="/" />} />
     </Routes>
   );

--- a/frontend/src/auth/ProtectedRoute.tsx
+++ b/frontend/src/auth/ProtectedRoute.tsx
@@ -1,0 +1,9 @@
+import { useAuth0 } from '@auth0/auth0-react';
+import { Navigate, Outlet } from 'react-router-dom';
+
+const ProtectedRoute = () => {
+  const { isAuthenticated } = useAuth0();
+  return isAuthenticated ? <Outlet /> : <Navigate to="/" replace />;
+};
+
+export default ProtectedRoute;


### PR DESCRIPTION
- Created a new ProtectedRoute component.
- Updated `AppRoutes.tsx` to use the ProtectedRoute component for the user profile page
- The user profile page now requires authentication to access

Testing:
- Verified that authenticated users can access the user profile page
- Confirmed that unauthenticated users are redirected to the home page when trying to access the user profile page 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR implements a protected route for the user profile page in the frontend. A new ProtectedRoute component has been created to handle authentication checks. The AppRoutes.tsx file has been updated to wrap the user profile route with the ProtectedRoute component, ensuring only authenticated users can access the profile page.
<br>
<br>
<b>Code change type</b>: Feature Addition, Security
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>