### PR TITLE
feat(frontend): Implement Create Restaurant API integration

### DIFF
--- a/frontend/src/api/MyRestaurantApi.tsx
+++ b/frontend/src/api/MyRestaurantApi.tsx
@@ -1,0 +1,46 @@
+import { Restaurant } from '@/types';
+import { useAuth0 } from '@auth0/auth0-react';
+import { useMutation } from 'react-query';
+import { toast } from 'sonner';
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
+export const useCreateMyRestaurant = () => {
+  const { getAccessTokenSilently } = useAuth0();
+
+  const createMyRestaurantRequest = async (
+    restaurantFormData: FormData
+  ): Promise<Restaurant> => {
+    const accessToken = await getAccessTokenSilently();
+
+    const response = await fetch(`${API_BASE_URL}/api/my/restaurant`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: restaurantFormData,
+    });
+
+    if (!response.ok) {
+      throw new Error('Failed to create restaurant');
+    }
+
+    return response.json();
+  };
+
+  const {
+    mutateAsync: createRestaurant,
+    isLoading,
+    isSuccess,
+    isError,
+  } = useMutation(createMyRestaurantRequest);
+
+  if (isError) {
+    toast.error('Failed to create restaurant');
+  }
+
+  if (isSuccess) {
+    toast.success('Restaurant created');
+  }
+  return { createRestaurant, isLoading };
+};

--- a/frontend/src/forms/manage-restaurant-form/ManageRestaurantForm.tsx
+++ b/frontend/src/forms/manage-restaurant-form/ManageRestaurantForm.tsx
@@ -9,6 +9,7 @@ import MenuSection from './MenuSection';
 import ImageSection from './ImageSection';
 import LoadingPageButton from '@/components/LoadingButton';
 import { Button } from '@/components/ui/button';
+import { Restaurant } from '@/types';
 
 const formSchema = z.object({
   restaurantName: z.string({
@@ -24,6 +25,12 @@ const formSchema = z.object({
     required_error: 'Delivery price is required',
     invalid_type_error: 'Delivery price must be a number',
   }),
+
+  estimatedDeliveryTime: z.coerce.number({
+    required_error: 'Estimated delivery time is required',
+    invalid_type_error: 'Estimated delivery time must be a number',
+  }),
+
   cuisines: z.array(z.string()).nonempty({
     message: 'Cuisines are required',
   }),
@@ -42,23 +49,44 @@ const formSchema = z.object({
   imageFile: z.instanceof(File, { message: 'Image is required' }),
 });
 
-type restaurantFormData = z.infer<typeof formSchema>;
+type RestaurantFormData = z.infer<typeof formSchema>;
 
 type Props = {
-  onSave: (restaurantFormData: FormData) => void;
+  onSave: (restaurantFormData: FormData) => Promise<Restaurant>;
   isLoading: boolean;
 };
 
-const onSubmit = (formDataJson: restaurantFormData) => {};
-
 const ManageRestaurantForm = ({ onSave, isLoading }: Props) => {
-  const form = useForm<restaurantFormData>({
+  const form = useForm<RestaurantFormData>({
     resolver: zodResolver(formSchema),
     defaultValues: {
       cuisines: [],
       menuItems: [{ name: '', price: 1 }],
     },
   });
+
+  const onSubmit = (formDataJson: RestaurantFormData) => {
+    const formData = new FormData();
+
+    formData.append('restaurantName', formDataJson.restaurantName);
+    formData.append('city', formDataJson.city);
+    formData.append('country', formDataJson.country);
+    formData.append('deliveryPrice', formDataJson.deliveryPrice.toString());
+    formData.append(
+      'estimatedDeliveryTime',
+      formDataJson.estimatedDeliveryTime.toString()
+    );
+    formDataJson.cuisines.forEach((cuisine, index) => {
+      formData.append(`cuisines[${index}]`, cuisine);
+    });
+    formDataJson.menuItems.forEach((menuItem, index) => {
+      formData.append(`menuItems[${index}][name]`, menuItem.name);
+      formData.append(`menuItems[${index}][price]`, menuItem.price.toString());
+    });
+    formData.append('imageFile', formDataJson.imageFile);
+
+    onSave(formData);
+  };
 
   return (
     <Form {...form}>

--- a/frontend/src/pages/ManageRestaurantPage.tsx
+++ b/frontend/src/pages/ManageRestaurantPage.tsx
@@ -1,7 +1,11 @@
+import { useCreateMyRestaurant } from '@/api/MyRestaurantApi';
 import ManageRestaurantForm from '@/forms/manage-restaurant-form/ManageRestaurantForm';
 
 const ManageRestaurantPage = () => {
-  return <ManageRestaurantForm />;
+  const { createRestaurant, isLoading } = useCreateMyRestaurant();
+  return (
+    <ManageRestaurantForm onSave={createRestaurant} isLoading={isLoading} />
+  );
 };
 
 export default ManageRestaurantPage;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -6,3 +6,22 @@ export type User = {
   city: string;
   country: string;
 };
+
+export type MenuItem = {
+  _id: string;
+  name: string;
+  price: number;
+};
+
+export type Restaurant = {
+  _id: string;
+  name: string;
+  city: string;
+  country: string;
+  deliveryPrice: number;
+  estimatedDeliveryTime: number;
+  cuisines: string[];
+  menuItems: MenuItem[];
+  imageUrl: string;
+  lastUpdated: string;
+};


### PR DESCRIPTION
- Add Restaurant and MenuItem types
- Prepare form data for API submission
- Integrate useCreateMyRestaurant hook in ManageRestaurantPage
- Update ManageRestaurantForm to handle form submission 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR implements the Create Restaurant API integration on the frontend. It introduces a new API hook for creating restaurants, updates the ManageRestaurantForm for data submission, integrates the API hook in ManageRestaurantPage, and adds new types for Restaurant and MenuItem. These changes enable users to create new restaurants through the frontend interface.
<br>
<br>
<b>Code change type</b>: Feature Addition, API Integration
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>