### PR TITLE
feature(frontend): Implement pagination for restaurant search results

### DIFF
--- a/frontend/src/api/RestaurantApi.tsx
+++ b/frontend/src/api/RestaurantApi.tsx
@@ -15,6 +15,7 @@ export const useSearchRestaurants = (
     const accessToken = await getAccessTokenSilently();
     const params = new URLSearchParams();
     params.set('searchQuery', searchState.searchQuery);
+    params.set('page', searchState.page.toString());
 
     const response = await fetch(
       `${API_BASE_URL}/api/restaurant/search/${encodeURIComponent(city)}?${params.toString()}`,

--- a/frontend/src/components/PaginationSelector.tsx
+++ b/frontend/src/components/PaginationSelector.tsx
@@ -1,0 +1,53 @@
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from './ui/pagination';
+
+type Props = {
+  page: number;
+  pages: number;
+  onPageChange: (page: number) => void;
+};
+
+const PaginationSelector = ({ page, pages, onPageChange }: Props) => {
+  const pageNumbers = Array.from({ length: pages }, (_, index) => index + 1);
+
+  return (
+    <Pagination>
+      <PaginationContent>
+        <PaginationItem>
+          {page !== 1 && (
+            <PaginationPrevious
+              href="#"
+              onClick={() => onPageChange(page - 1)}
+            />
+          )}
+        </PaginationItem>
+
+        {pageNumbers.map((pageNumber) => (
+          <PaginationItem key={pageNumber}>
+            <PaginationLink
+              href="#"
+              isActive={pageNumber === page}
+              onClick={() => onPageChange(pageNumber)}
+            >
+              {pageNumber}
+            </PaginationLink>
+          </PaginationItem>
+        ))}
+
+        <PaginationItem>
+          {page !== pages && (
+            <PaginationNext href="#" onClick={() => onPageChange(page + 1)} />
+          )}
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  );
+};
+
+export default PaginationSelector;

--- a/frontend/src/components/ui/pagination.tsx
+++ b/frontend/src/components/ui/pagination.tsx
@@ -1,0 +1,121 @@
+import * as React from 'react';
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  DotsHorizontalIcon,
+} from '@radix-ui/react-icons';
+
+import { cn } from '@/lib/utils';
+import { ButtonProps, buttonVariants } from '@/components/ui/button';
+
+const Pagination = ({ className, ...props }: React.ComponentProps<'nav'>) => (
+  <nav
+    role="navigation"
+    aria-label="pagination"
+    className={cn('mx-auto flex w-full justify-center', className)}
+    {...props}
+  />
+);
+Pagination.displayName = 'Pagination';
+
+const PaginationContent = React.forwardRef<
+  HTMLUListElement,
+  React.ComponentProps<'ul'>
+>(({ className, ...props }, ref) => (
+  <ul
+    ref={ref}
+    className={cn('flex flex-row items-center gap-1', className)}
+    {...props}
+  />
+));
+PaginationContent.displayName = 'PaginationContent';
+
+const PaginationItem = React.forwardRef<
+  HTMLLIElement,
+  React.ComponentProps<'li'>
+>(({ className, ...props }, ref) => (
+  <li ref={ref} className={cn('', className)} {...props} />
+));
+PaginationItem.displayName = 'PaginationItem';
+
+type PaginationLinkProps = {
+  isActive?: boolean;
+} & Pick<ButtonProps, 'size'> &
+  React.ComponentProps<'a'>;
+
+const PaginationLink = ({
+  className,
+  isActive,
+  size = 'icon',
+  ...props
+}: PaginationLinkProps) => (
+  <a
+    aria-current={isActive ? 'page' : undefined}
+    className={cn(
+      buttonVariants({
+        variant: isActive ? 'outline' : 'ghost',
+        size,
+      }),
+      className
+    )}
+    {...props}
+  />
+);
+PaginationLink.displayName = 'PaginationLink';
+
+const PaginationPrevious = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) => (
+  <PaginationLink
+    aria-label="Go to previous page"
+    size="default"
+    className={cn('gap-1 pl-2.5', className)}
+    {...props}
+  >
+    <ChevronLeftIcon className="h-4 w-4" />
+    <span>Previous</span>
+  </PaginationLink>
+);
+PaginationPrevious.displayName = 'PaginationPrevious';
+
+const PaginationNext = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) => (
+  <PaginationLink
+    aria-label="Go to next page"
+    size="default"
+    className={cn('gap-1 pr-2.5', className)}
+    {...props}
+  >
+    <span>Next</span>
+    <ChevronRightIcon className="h-4 w-4" />
+  </PaginationLink>
+);
+PaginationNext.displayName = 'PaginationNext';
+
+const PaginationEllipsis = ({
+  className,
+  ...props
+}: React.ComponentProps<'span'>) => (
+  <span
+    aria-hidden
+    className={cn('flex h-9 w-9 items-center justify-center', className)}
+    {...props}
+  >
+    <DotsHorizontalIcon className="h-4 w-4" />
+    <span className="sr-only">More pages</span>
+  </span>
+);
+PaginationEllipsis.displayName = 'PaginationEllipsis';
+
+export {
+  Pagination,
+  PaginationContent,
+  PaginationLink,
+  PaginationItem,
+  PaginationPrevious,
+  PaginationNext,
+  PaginationEllipsis,
+};

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -1,25 +1,37 @@
 import { useSearchRestaurants } from '@/api/RestaurantApi';
+import PaginationSelector from '@/components/PaginationSelector';
 import SearchBar, { SearchForm } from '@/components/SearchBar';
 import SearchResultCard from '@/components/SearchResultCard';
 import SearchResultInfo from '@/components/SearchResultInfo';
+
 import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 
 export type SearchState = {
   searchQuery: string;
+  page: number;
 };
 
 const SearchPage = () => {
   const { city } = useParams<{ city: string }>();
   const [searchState, setSearchState] = useState<SearchState>({
     searchQuery: '',
+    page: 1,
   });
   const { results, isLoading } = useSearchRestaurants(searchState, city);
+
+  const setPage = (page: number) => {
+    setSearchState((prevState) => ({
+      ...prevState,
+      page,
+    }));
+  };
 
   const setSearchQuery = (searchFormDate: SearchForm) => {
     setSearchState((prevState) => ({
       ...prevState,
       searchQuery: searchFormDate.searchQuery,
+      page: 1,
     }));
   };
 
@@ -27,6 +39,7 @@ const SearchPage = () => {
     setSearchState((prevState) => ({
       ...prevState,
       searchQuery: '',
+      page: 1,
     }));
   };
 
@@ -52,6 +65,11 @@ const SearchPage = () => {
         {results.data.map((restaurant) => (
           <SearchResultCard key={restaurant._id} restaurant={restaurant} />
         ))}
+        <PaginationSelector
+          page={results.pagination.page}
+          pages={results.pagination.pages}
+          onPageChange={setPage}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
- Integrate shadcn pagination component
- Add PaginationSelector component for page navigation
- Enhance SearchState type to include page number
- Reset page to 1 when new search query is submitted or search is reset
- Display PaginationSelector at the bottom of search results
- Update RestaurantApi to include page parameter in API requests 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR implements pagination for restaurant search results, introducing a PaginationSelector component and updating SearchBar and SearchResults. It enhances SearchState with page information, modifies RestaurantApi for server-side pagination, and ensures page reset on new searches or resets.
<br>
<br>
<b>Code change type</b>: Feature Addition, Refactoring
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>