### PR TITLE
feat(backend): add endpoint to fetch user order history

### DIFF
--- a/backend/src/controllers/OrderController.ts
+++ b/backend/src/controllers/OrderController.ts
@@ -152,7 +152,21 @@ const stripeWebhookHandler = async (req: Request, res: Response, next: NextFunct
   }
 };
 
+const getMyOrders = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const orders = await Order.find({ user: req.userId }).populate('restaurant').populate('user');
+    return res.status(200).json(orders);
+  } catch (error) {
+    logger.error(
+      `Error fetching my orders: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      { stack: error instanceof Error ? error.stack : undefined },
+    );
+    next(error);
+  }
+};
+
 export default {
   createCheckoutSession,
   stripeWebhookHandler,
+  getMyOrders,
 };

--- a/backend/src/routes/OrderRoute.ts
+++ b/backend/src/routes/OrderRoute.ts
@@ -12,5 +12,6 @@ router.post(
 );
 
 router.post('/checkout/webhook', OrderController.stripeWebhookHandler);
+router.get('/', jwtCheck, jwtParse, OrderController.getMyOrders);
 
 export default router;


### PR DESCRIPTION
- Add GET /api/order endpoint to retrieve user's orders
- Implement getMyOrders controller with authentication
- Include populated restaurant and user details in response 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR introduces a new GET endpoint '/api/order' to fetch a user's order history. It adds a 'getMyOrders' function in OrderController.ts, which retrieves authenticated user's orders with populated restaurant and user details. The new route is added to OrderRoute.ts with proper authentication middleware.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>